### PR TITLE
This change modifies the 'Help URL' section to point to a URL of user's choice with proper horizon_config attribute.

### DIFF
--- a/doc/common/dashboard_customizing.rst
+++ b/doc/common/dashboard_customizing.rst
@@ -134,6 +134,7 @@ Help URL
 
    .. code-block:: python
 
-      'help_url': "http://openstack.mycompany.org"
+     HORIZON_CONFIG["help_url"] = "http://openstack.mycompany.org"
 
 #. Restart Apache for this change to take effect.
+#. Load Horizon


### PR DESCRIPTION
Closes bug : 1578008.
